### PR TITLE
Fix #2: properly encodeURIComponent query. also no docpad

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 	<button type="button" id="aboutbutton">About</button>
 </div>
 <div id="abouttext">
-	<p>Google Direct is a tool that allows you to easily search misplaced files on the internet. It was developed by Akshay S Dinesh, inspired by <a href="http://www.quora.com/What-can-I-learn-right-now-in-10-minutes-that-will-be-useful-for-the-rest-of-my-life/answer/Shibu-Lijack">this answer on quora</a>. This site is built using yo docpad, by following <a href="https://developer.mozilla.org/en/docs/">Mozilla developer docs</a> and hosted on <a href="https://github.com">github</a>.</p>
+	<p>Google Direct is a tool that allows you to easily search misplaced files on the internet. It was developed by Akshay S Dinesh, inspired by <a href="http://www.quora.com/What-can-I-learn-right-now-in-10-minutes-that-will-be-useful-for-the-rest-of-my-life/answer/Shibu-Lijack">this answer on quora</a>. This site is built by following <a href="https://developer.mozilla.org/en/docs/">Mozilla developer docs</a> and hosted on <a href="https://github.com">github</a>.</p>
 </div>
 </footer>
 

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 function doSearch(e){
 	if (e.preventDefault) e.preventDefault();
 	var query = document.getElementById('query').value;
-	window.location.assign("https://www.google.com/search?q="+query+" -inurl:(htm|html|php|pls|txt) intitle:index.of \"last modified\" (mkv|mp4|avi|epub|pdf|mp3)");
+	window.location.assign("https://www.google.com/search?q=" + encodeURIComponent(query) + " -inurl:(htm|html|php|pls|txt) intitle:index.of \"last modified\" (mkv|mp4|avi|epub|pdf|mp3)");
 	return false;
 }
 
@@ -31,4 +31,3 @@ if (aboutbutton.attachEvent) {
 } else {
     aboutbutton.addEventListener("click", toggleAbout);
 }
-


### PR DESCRIPTION
otherwise queries with characters like & would be destroyed.

This commit onwards we are not going to rely on docpad anymore.